### PR TITLE
added autonomous oskar rfid cloner

### DIFF
--- a/arc/Makefile
+++ b/arc/Makefile
@@ -1,0 +1,27 @@
+TARGET=arc
+ARCH=LPC13
+CPU=$(ARCH)42
+DEBUG=-g
+OPTIM=-O2 -mword-relocations
+
+APP_CFLAGS=-Iinc -std=gnu99 -fgnu89-inline -D__USE_CMSIS -DDEBUG
+APP_LDFLAGS=-lm
+
+APP_SRC= \
+  src/main.c \
+  src/arc.c \
+  src/libnfc.c \
+  src/usbserial.c
+
+APP_SRC+=$(IMAGES_C)
+
+all: $(TARGET).bin
+
+indent:
+	find src inc -iname '*.[ch]' -exec indent -c81 -i4 -cli4 -bli0 -ts 4 \{\} \;
+	rm -f src/*.[ch]~ inc/*.[ch]~
+
+app_clean:
+	find src -name '*.o' -exec rm \{\} \;
+
+include ../core/Makefile.rules

--- a/arc/inc/arc.h
+++ b/arc/inc/arc.h
@@ -1,0 +1,21 @@
+#ifndef __ARC_H__
+#define __ARC_H__
+
+#define MIFARE_KEY_SIZE     6
+#define MIFARE_CARD_SIZE    1024
+#define BLOCKS              64
+#define BLOCK_SIZE          16
+#define SECTORS             16
+#define ACCESS_BYTES        4
+#define KEYS                24
+
+#define READ    0
+#define WRITE   1
+
+extern uint8_t submenu;
+extern uint8_t status;
+
+void loop_clone_rfid(void (*f)(void));
+void dump_mifare_card(void);
+
+#endif/*__ARC_H__*/

--- a/arc/inc/config.h
+++ b/arc/inc/config.h
@@ -1,0 +1,66 @@
+/***************************************************************
+ *
+ * OpenBeacon.org - config file
+ *
+ * Copyright 2010 Milosch Meriac <meriac@openbeacon.de>
+ *
+ ***************************************************************
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; version 2.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ */
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+#ifdef  DEBUG
+#define debug(args...) debug_printf(args)
+#else  /* no DEBUG enable - remove debug code */
+#define debug(...) {}
+#endif /*DEBUG*/
+
+#define LED_PORT 1																/* Port for led                      */
+#define LED_PORT_1 1															/* Port for led                      */
+#define LED_PORT_0 0															/* Port for led                      */
+#define LED_BIT 9																/* Bit on port for led               */
+#define LED_ON 1																/* Level to set port to turn on led  */
+#define LED_OFF 0																/* Level to set port to turn off led */
+
+#define ENABLE_USB_FULLFEATURED
+
+/* USB device settings */
+#ifdef  ENABLE_USB_FULLFEATURED
+#define USB_VENDOR_ID	0x2366
+#define USB_PROD_ID	0x0009
+#define USB_DEVICE	0x0100
+#endif /*ENABLE_USB_FULLFEATURED */
+
+/* Clock Definition */
+#define SYSTEM_CRYSTAL_CLOCK 12000000
+#define SYSTEM_CORE_CLOCK (SYSTEM_CRYSTAL_CLOCK*6)
+
+/* Enable RFID support */
+#define ENABLE_PN532_RFID
+/* PN532 pin definitions */
+#define PN532_RESET_PORT 1
+#define PN532_RESET_PIN 11
+#define PN532_IRQ_PORT 1
+#define PN532_IRQ_PIN 4
+#define PN532_CS_PORT 0
+#define PN532_CS_PIN 2
+
+/* SPI_CS(io_port, io_pin, CPSDVSR frequency, mode) */
+#define SPI_CS_PN532 SPI_CS( PN532_CS_PORT, PN532_CS_PIN, 64, SPI_CS_MODE_SKIP_TX|SPI_CS_MODE_BIT_REVERSED )
+
+#endif/*__CONFIG_H__*/

--- a/arc/inc/libnfc.h
+++ b/arc/inc/libnfc.h
@@ -1,0 +1,46 @@
+#ifndef __LIBNFC_H__
+#define __LIBNFC_H__
+
+#define PN532_FIFO_SIZE 64
+#define PN532_MAX_PAYLAOADSIZE 264
+#define PN532_MAX_PACKET_SIZE (PN532_MAX_PAYLAOADSIZE+11)
+
+#define CLONE   0
+#define LIBNFC  1
+
+extern uint8_t main_menu;
+
+typedef enum {
+	STATE_IDLE = 0,
+	STATE_PREFIX = -1,
+	STATE_PREFIX_EXT = -2,
+	STATE_HEADER = -3,
+	STATE_WAKEUP = -4,
+	STATE_FIFOFLUSH = -5,
+	STATE_PAYLOAD = -6,
+	STATE_FLOWCTRL = -7
+} PN532_State;
+
+typedef struct {
+	uint32_t last_seen;
+	uint16_t reserved;
+	uint16_t pos;
+	uint16_t expected;
+	uint8_t data_prev;
+	uint8_t wakeup;
+	uint8_t crc;
+	uint8_t tfi;
+	PN532_State state;
+	uint8_t data[PN532_MAX_PACKET_SIZE + 1];
+} PN532_Packet;
+
+
+void packet_init(PN532_Packet * pkt, uint8_t reserved, uint8_t tfi);
+void packet_reset(PN532_Packet * pkt);
+int packet_put(PN532_Packet * pkt, uint8_t data);
+void dump_packet(uint8_t * data, int count);
+void rfid_hexdump(const void *buffer, int size);
+void get_firmware_version(void);
+void loop_libnfc_rfid(void);
+
+#endif/*__LIBNFC_H__*/

--- a/arc/inc/usbcfg.h
+++ b/arc/inc/usbcfg.h
@@ -1,0 +1,157 @@
+/*----------------------------------------------------------------------------
+ *      U S B  -  K e r n e l
+ *----------------------------------------------------------------------------
+ * Name:    usbcfg.h
+ * Purpose: USB Custom Configuration
+ * Version: V1.20
+ *----------------------------------------------------------------------------
+ *      This software is supplied "AS IS" without any warranties, express,
+ *      implied or statutory, including but not limited to the implied
+ *      warranties of fitness for purpose, satisfactory quality and
+ *      noninfringement. Keil extends you a royalty-free right to reproduce
+ *      and distribute executable files created using this software for use
+ *      on NXP Semiconductors LPC microcontroller devices only. Nothing else 
+ *      gives you the right to use this software.
+ *
+ * Copyright (c) 2009 Keil - An ARM Company. All rights reserved.
+ *----------------------------------------------------------------------------
+ * History:
+ *          V1.20 Added vendor specific support
+ *          V1.00 Initial Version
+ *---------------------------------------------------------------------------*/
+
+#ifndef __USBCFG_H__
+#define __USBCFG_H__
+
+
+//*** <<< Use Configuration Wizard in Context Menu >>> ***
+
+
+/*
+// <h> USB Configuration
+//   <o0> USB Power
+//        <i> Default Power Setting
+//        <0=> Bus-powered
+//        <1=> Self-powered
+//   <o1> Max Number of Interfaces <1-256>
+//   <o2> Max Number of Endpoints  <1-32>
+//   <o3> Max Endpoint 0 Packet Size
+//        <8=> 8 Bytes <16=> 16 Bytes <32=> 32 Bytes <64=> 64 Bytes
+//   <e4> DMA Transfer
+//     <i> Use DMA for selected Endpoints
+//     <o5.0>  Endpoint 0 Out
+//     <o5.1>  Endpoint 0 In
+//     <o5.2>  Endpoint 1 Out
+//     <o5.3>  Endpoint 1 In
+//     <o5.4>  Endpoint 2 Out
+//     <o5.5>  Endpoint 2 In
+//     <o5.6>  Endpoint 3 Out
+//     <o5.7>  Endpoint 3 In
+//     <o5.8>  Endpoint 4 Out
+//     <o5.9>  Endpoint 4 In
+//   </e>
+// </h>
+*/
+
+#define USB_POWER           0
+#define USB_IF_NUM          1
+#define USB_LOGIC_EP_NUM    5
+#define USB_EP_NUM          10
+#define USB_MAX_PACKET0     64
+
+/*
+// <h> USB Event Handlers
+//   <h> Device Events
+//     <o0.0> Power Event
+//     <o1.0> Reset Event
+//     <o2.0> Suspend Event
+//     <o3.0> Resume Event
+//     <o4.0> Remote Wakeup Event
+//     <o5.0> Start of Frame Event
+//     <o6.0> Error Event
+//   </h>
+//   <h> Endpoint Events
+//     <o7.0>  Endpoint 0 Event
+//     <o7.1>  Endpoint 1 Event
+//     <o7.2>  Endpoint 2 Event
+//     <o7.3>  Endpoint 3 Event
+//     <o7.4>  Endpoint 4 Event
+//     <o7.5>  Endpoint 5 Event
+//     <o7.6>  Endpoint 6 Event
+//     <o7.7>  Endpoint 7 Event
+//     <o7.8>  Endpoint 8 Event
+//     <o7.9>  Endpoint 9 Event
+//     <o7.10> Endpoint 10 Event
+//     <o7.11> Endpoint 11 Event
+//     <o7.12> Endpoint 12 Event
+//     <o7.13> Endpoint 13 Event
+//     <o7.14> Endpoint 14 Event
+//     <o7.15> Endpoint 15 Event
+//   </h>
+//   <h> USB Core Events
+//     <o8.0>  Set Configuration Event
+//     <o9.0>  Set Interface Event
+//     <o10.0> Set/Clear Feature Event
+//   </h>
+// </h>
+*/
+
+#define USB_POWER_EVENT     0
+#define USB_RESET_EVENT     1
+#define USB_SUSPEND_EVENT   1
+#define USB_RESUME_EVENT    1
+#define USB_WAKEUP_EVENT    0
+#define USB_SOF_EVENT       0
+#define USB_ERROR_EVENT     0
+#define USB_EP_EVENT        0x000B
+#define USB_CONFIGURE_EVENT 1
+#define USB_INTERFACE_EVENT 0
+#define USB_FEATURE_EVENT   0
+
+
+/*
+// <e0> USB Class Support
+//   <i> enables USB Class specific Requests
+//   <e1> Human Interface Device (HID)
+//     <o2> Interface Number <0-255>
+//   </e>
+//   <e3> Mass Storage
+//     <o4> Interface Number <0-255>
+//   </e>
+//   <e5> Audio Device
+//     <o6> Control Interface Number <0-255>
+//     <o7> Streaming Interface 1 Number <0-255>
+//     <o8> Streaming Interface 2 Number <0-255>
+//   </e>
+//   <e9> Communication Device
+//     <o10> Control Interface Number <0-255>
+//     <o11> Bulk Interface Number <0-255>
+//     <o12> Max Communication Device Buffer Size
+//        <8=> 8 Bytes <16=> 16 Bytes <32=> 32 Bytes <64=> 64 Bytes 
+//   </e>
+// </e>
+*/
+
+#define USB_CLASS           1
+#define USB_HID             0
+#define USB_HID_IF_NUM      0
+#define USB_MSC             0
+#define USB_MSC_IF_NUM      0
+#define USB_AUDIO           0
+#define USB_ADC_CIF_NUM     0
+#define USB_ADC_SIF1_NUM    1
+#define USB_ADC_SIF2_NUM    2
+#define USB_CDC             1
+#define USB_CDC_CIF_NUM     0
+#define USB_CDC_DIF_NUM     1
+#define USB_CDC_BUFSIZE     64
+
+/*
+// <e0> USB Vendor Support
+//   <i> enables USB Vendor specific Requests
+// </e>
+*/
+#define USB_VENDOR          0
+
+
+#endif /* __USBCFG_H__ */

--- a/arc/inc/usbserial.h
+++ b/arc/inc/usbserial.h
@@ -1,0 +1,34 @@
+/***************************************************************
+ *
+ * OpenBeacon.org - application specific USB functionality
+ *
+ * Copyright 2010 Milosch Meriac <meriac@openbeacon.de>
+ *
+ ***************************************************************
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; version 2.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ */
+
+#ifndef __USBSERIAL_H__
+#define __USBSERIAL_H__
+
+#ifdef  ENABLE_USB_FULLFEATURED
+extern void usb_init (void);
+extern void usb_flush (void);
+extern int usb_getchar (void);
+extern int usb_putchar (uint8_t data);
+#endif /*ENABLE_USB_FULLFEATURED */
+
+#endif/*__USBSERIAL_H__*/

--- a/arc/src/arc.c
+++ b/arc/src/arc.c
@@ -1,0 +1,221 @@
+#define _XOPEN_SOURCE 9001
+#include <openbeacon.h>
+#include "arc.h"
+#include "libnfc.h"
+
+uint8_t mifare_card[MIFARE_CARD_SIZE];
+
+uint8_t default_keys[][MIFARE_KEY_SIZE] = 
+    { 
+    {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+    {0x0f, 0x5f, 0xb2, 0x9d, 0xdc, 0x10}, 
+    {0x25, 0xe5, 0xb3, 0x47, 0x75, 0x06}, 
+    {0x63, 0x15, 0xd5, 0x6b, 0x21, 0xf4}, 
+    {0x66, 0x47, 0x0d, 0xe8, 0xaa, 0x11}, 
+    {0x7a, 0x46, 0x38, 0x61, 0xb1, 0xec}, 
+    {0x7c, 0x56, 0x37, 0xd4, 0x02, 0x40}, 
+    {0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5}, 
+    {0xa2, 0x7d, 0x38, 0x04, 0xc2, 0x59}, 
+    {0xbc, 0x0b, 0x0c, 0x6b, 0xb4, 0xec}, 
+    {0xc8, 0x27, 0x32, 0x52, 0x23, 0xb3}, 
+    {0xc8, 0xb4, 0x70, 0xc4, 0x8f, 0x77}, 
+    {0xca, 0x0f, 0xb8, 0x30, 0x93, 0xc6}, 
+    {0xfe, 0x39, 0xef, 0x4d, 0x55, 0xe1},
+    {0xd3, 0xf7, 0xd3, 0xf7, 0xd3, 0xf7}, // NFCForum content key
+    {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, // Blank key
+    {0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5},
+    {0x4d, 0x3a, 0x99, 0xc3, 0x51, 0xdd},
+    {0x1a, 0x98, 0x2c, 0x7e, 0x45, 0x9a},
+    {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+    {0x71, 0x4c, 0x5c, 0x88, 0x6e, 0x97},
+    {0x58, 0x7e, 0xe5, 0xf9, 0x35, 0x0f},
+    {0xa0, 0x47, 0x8c, 0xc3, 0x90, 0x91},
+    {0x53, 0x3c, 0xb6, 0xc7, 0x23, 0xf6},
+    {0x8f, 0xd0, 0xa4, 0xf2, 0x56, 0xe9}
+    };
+
+uint8_t access_bytes[ACCESS_BYTES] = 
+    {
+    0xFF, 0x07, 0x80, 0x69 /* AB rw Access */
+    };
+
+uint8_t key_b[MIFARE_KEY_SIZE] = 
+    {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF /* B Access Key */
+    };
+
+int turn_rf_off (uint8_t *data, uint8_t size) {
+    /* wait 0.5s */
+    pmu_wait_ms(5);
+
+    /* turning field off */
+    data[0] = PN532_CMD_RFConfiguration;
+    data[1] = 0x01;	/* CfgItem = 0x01 */
+    data[2] = 0x00;	/* RF Field = off */
+    return rfid_execute(&data[0], 3, size);
+}
+
+int mifare_reader_init(uint8_t *data, uint8_t size)
+{
+
+	/* User Manual S.97 141520.pdf */
+	data[0] = PN532_CMD_SAMConfiguration; /* 0x14 */
+	data[1] = 0x01;		/* Normal Mode */
+	return rfid_execute(&data[0], 2, size);
+}
+
+void dump_mifare_card (void)
+{
+    for (uint8_t i = 0; i < BLOCKS; i++) {
+        debug_printf("Block: %2d", i);
+        rfid_hexdump(&mifare_card[i*BLOCK_SIZE], BLOCK_SIZE);
+    }
+}
+
+int initiator_init(uint8_t *data, uint8_t size)
+{
+    data[0] = PN532_CMD_InListPassiveTarget; /* 0x4a */
+    data[1] = 0x01;	/* MaxTg - maximum cards */
+    data[2] = 0x00;	/* BrTy - 106 kbps type A */
+    return rfid_execute(&data[0], 3, size);
+}
+
+int mifare_authenticate_block(uint8_t *data, uint8_t size, uint8_t block)
+{
+
+    data[0] = PN532_CMD_InDataExchange; /* 0x40 */
+    data[1] = 0x01;	/* card 1 */
+    data[2] = 0x60;	/* MIFARE authenticate A */
+    data[3] = block;
+    return rfid_execute(&data[0], 14, size);
+
+}
+
+void set_uid(uint8_t *data, int oid)
+{
+    /* MIFARE NFCID1 */
+    memcpy(&data[10], &oid, sizeof(oid));
+}
+
+void set_key(uint8_t *data, uint8_t keyindex)
+{
+    /* MIFARE default key 6*0xFF */
+    memcpy(&data[4], &default_keys[keyindex], MIFARE_KEY_SIZE);
+}
+
+
+int mifare_read_block(uint8_t *data, uint8_t size, uint8_t block)
+{
+
+    data[0] = PN532_CMD_InDataExchange; /* 0x40 */
+    data[1] = 0x01;	    /* card 1 */
+    data[2] = 0x30;	    /* MIFARE read 16 bytes */
+    data[3] = block;    /* block 1 */
+    return rfid_execute(&data[0], 4, size);
+
+}
+
+int mifare_write_block(uint8_t *data, uint8_t size, uint8_t block)
+{
+
+    data[0] = PN532_CMD_InDataExchange; /* 0x40 */
+    data[1] = 0x01;	    /* card 1 */
+    data[2] = 0xA0;	    /* MIFARE write 16 bytes */
+    data[3] = block;    /* block 1 */
+    return rfid_execute(&data[0], 20, size);
+
+}
+
+
+void loop_clone_rfid(void (*f)(void))
+{
+    uint8_t data[80];
+    uint8_t keyindex = 0;
+    uint8_t block = 0;
+    uint8_t tries = 0;
+    int res, oid;
+
+	get_firmware_version();
+
+    while (block < BLOCKS) {
+        if ( READ != main_menu) { break; }
+        res = mifare_reader_init(data, sizeof(data));
+
+        if (tries >= KEYS) {
+            block += 1;
+        }
+
+        if (res >= 0) {
+            res = initiator_init(data, sizeof(data));
+
+            if (res >= 11) {
+                if (0x00 == data[3] && data[6] >= 0x04) {
+                    memcpy(&oid, &data[7], sizeof(oid));
+                    if (0x00 == block) {
+                        debug_printf("MIFARE_CARD_ID:");
+                        rfid_hexdump(&oid, sizeof(oid));
+                    }
+
+                    set_uid(data, oid);
+                    set_key(data, keyindex);
+
+                    res = mifare_authenticate_block(data, sizeof(data), block);
+
+/*
+                    debug_printf("res:");
+                    rfid_hexdump(&res, sizeof(res));
+
+                    debug_printf("data:");
+                    rfid_hexdump(&data[0], sizeof(data));
+*/
+
+                    if (0x41 == data[0] && 0x00 == data[1]) {
+                        debug_printf("Auth Succeeded.\n");
+                        tries = 0;
+
+                        switch (submenu) {
+                            case READ:
+                                res = mifare_read_block(data, sizeof(data), block);
+
+                                if (res == 18) {
+                                    debug_printf("Block:");
+                                    rfid_hexdump(&block, sizeof(block));
+                                    debug_printf("Data:");
+                                    rfid_hexdump(&data[2], BLOCK_SIZE);
+                                    debug_printf("Key:");
+                                    rfid_hexdump(&default_keys[keyindex], MIFARE_KEY_SIZE);
+
+                                    memcpy(&mifare_card[block*BLOCK_SIZE], &data[2], BLOCK_SIZE);
+                                    if (0x00 == (block+1) % 4) {
+                                        memcpy(&mifare_card[block*BLOCK_SIZE], &default_keys[keyindex], MIFARE_KEY_SIZE);
+                                        memcpy(&mifare_card[block*BLOCK_SIZE+6], &access_bytes[0], ACCESS_BYTES);
+                                        memcpy(&mifare_card[block*BLOCK_SIZE+10], &key_b[0], MIFARE_KEY_SIZE);
+                                    }
+                                }
+                            break;
+                            case WRITE:
+                                memcpy(&data[4], &mifare_card[block*BLOCK_SIZE], BLOCK_SIZE);
+                                res = mifare_write_block(data, sizeof(data), block);
+                                debug_printf("res:");
+                                rfid_hexdump(&res, sizeof(res));
+                            break;
+                        }
+                        if (BLOCKS-1 == block) {
+                            status = 1;
+                        }
+                        block += 1;
+                    } else if (0x41 == data[0] && 0x14 == data[1]) {
+                        debug_printf("Auth Failed.\n");
+                        keyindex = (keyindex + 1) % KEYS;
+                        tries += 1;
+                    }
+                }
+            }
+        }
+        turn_rf_off(data, sizeof(data));
+    }
+    if (0x01 == status) {
+        (*f)();
+    }
+    main_menu = LIBNFC;
+}

--- a/arc/src/libnfc.c
+++ b/arc/src/libnfc.c
@@ -1,0 +1,337 @@
+#define _XOPEN_SOURCE 9001
+#include <openbeacon.h>
+#include "libnfc.h"
+#include "usbserial.h"
+
+
+void packet_init(PN532_Packet * pkt, uint8_t reserved, uint8_t tfi)
+{
+	memset(pkt, 0, sizeof(*pkt));
+	pkt->reserved = reserved;
+	pkt->tfi = tfi;
+	pkt->data_prev = 0x01;
+}
+
+void packet_reset(PN532_Packet * pkt)
+{
+	packet_init(pkt, pkt->reserved, pkt->tfi);
+}
+
+int packet_put(PN532_Packet * pkt, uint8_t data)
+{
+	PN532_State res;
+	uint8_t len, lcs;
+	const uint8_t prefix[] = { 0x00, 0x00, 0xFF };
+
+	res = pkt->state;
+
+	switch (pkt->state) {
+	case STATE_WAKEUP:
+		{
+			debug("\nWAKEUP\n");
+			pmu_wait_ms(50);
+			res = STATE_IDLE;
+			/* intentionally no 'break;' */
+		}
+
+	case STATE_IDLE:
+		{
+			/* TODO: WTF? - need to wait for one character */
+			debug_printf(".");
+
+			/* if needed, delete packet from previous run */
+			if (pkt->pos) {
+				packet_reset(pkt);
+				break;
+			}
+
+			/* scan for 0x00+0xFF prefix */
+			if (data == 0xFF && pkt->data_prev == 0x00) {
+				memcpy(&pkt->data[pkt->reserved], prefix,
+				       sizeof(prefix));
+				/* add size of reserved+prefix to packet pos */
+				pkt->pos = pkt->reserved + sizeof(prefix);
+				/* expect at least a short frame */
+				pkt->expected = pkt->pos + 2;
+				/* switch to prefix reception mode */
+				res = STATE_FLOWCTRL;
+				break;
+			}
+
+			/* scan for HSU wakeup */
+			if (data == 0x55 && pkt->data_prev == 0x55)
+				/* wait for three times 0x00 */
+				pkt->wakeup = 3;
+			else if (pkt->wakeup) {
+				if (data)
+					pkt->wakeup = 0;
+				else {
+					pkt->wakeup--;
+					if (!pkt->wakeup) {
+						res = STATE_WAKEUP;
+						break;
+					}
+				}
+			}
+
+			break;
+		}
+
+	case STATE_FLOWCTRL:
+		{
+			pkt->data[pkt->pos++] = data;
+			if (pkt->pos >= pkt->expected) {
+				lcs = pkt->data[pkt->pos - 1];
+				len = pkt->data[pkt->pos - 2];
+
+				/* detected extended frame */
+				if (len == 0xFF && lcs == 0xFF) {
+					debug("IR: extended frame\n");
+					/* expect three more bytes for extended frame */
+					pkt->expected += 4;
+					res = STATE_PREFIX_EXT;
+					break;
+				}
+
+				/* detected ACK frame */
+				if (len == 0xFF && lcs == 0x00) {
+					res = pkt->pos;
+					break;
+				}
+
+				/* detected NACK frame */
+				if (len == 0x00 && lcs == 0xFF) {
+					res = pkt->pos;
+					break;
+				}
+
+				pkt->expected++;
+				res = STATE_PREFIX;
+			}
+
+			break;
+		}
+
+	case STATE_PREFIX:
+		{
+			pkt->data[pkt->pos++] = data;
+			if (pkt->pos >= pkt->expected) {
+				lcs = pkt->data[pkt->pos - 2];
+				len = pkt->data[pkt->pos - 3];
+
+				if (len == 0x01 && lcs == 0xFF) {
+					pkt->expected += len;
+					pkt->crc = pkt->data[pkt->pos - 1];
+					res = STATE_PAYLOAD;
+					break;
+				}
+
+				/* if valid short packet */
+				if (((uint8_t) (len + lcs)) == 0) {
+					pkt->expected += len;
+
+					/*detect oversized packets */
+					if (pkt->expected >
+					    PN532_MAX_PACKET_SIZE) {
+						packet_reset(pkt);
+						res = STATE_IDLE;
+					} else {
+						/* check for TFI */
+						if (pkt->data[pkt->pos - 1] ==
+						    pkt->tfi) {
+							/* maintain CRC including TFI */
+							pkt->crc = pkt->tfi;
+							res = STATE_PAYLOAD;
+						} else {
+							packet_reset(pkt);
+							res = STATE_IDLE;
+						}
+					}
+
+					break;
+				}
+			}
+			break;
+		}
+
+	case STATE_PREFIX_EXT:
+		{
+			/* TODO: add extended frame support */
+			debug("IR: extended frame is not yet supported\n");
+			packet_reset(pkt);
+			res = STATE_IDLE;
+			break;
+		}
+
+	case STATE_PAYLOAD:
+		{
+			pkt->data[pkt->pos++] = data;
+			pkt->crc += data;
+
+			if (pkt->pos >= pkt->expected) {
+				if (pkt->crc) {
+					debug("IR: packet CRC error [0x%02X]\n",
+					      pkt->crc);
+					packet_reset(pkt);
+					res = STATE_IDLE;
+				} else
+					res = pkt->pos;
+			}
+			break;
+		}
+
+	default:
+		{
+			debug("IR: unknown state!!!\n");
+			packet_reset(pkt);
+			res = STATE_IDLE;
+		}
+	}
+
+	pkt->data_prev = data;
+	pkt->state = (res > 0) ? STATE_IDLE : res;
+
+	return res;
+}
+
+void dump_packet(uint8_t * data, int count)
+{
+	int i;
+	for (i = 0; i < count; i++)
+		debug_printf("%c%02X", 6 == i % 7 ? '*' : ' ', *data++);
+	debug_printf("\n");
+}
+
+void rfid_hexdump(const void *buffer, int size)
+{
+	int i;
+	const unsigned char *p = (unsigned char *)buffer;
+
+	for (i = 0; i < size; i++) {
+		if (i && ((i & 3) == 0))
+			debug_printf(" ");
+		debug_printf(" %02X", *p++);
+	}
+	debug_printf(" [size=%02i]\n", size);
+}
+
+/* get firmware version */
+void get_firmware_version(void)
+{
+	int i;
+	uint8_t data;
+	uint8_t output[PN532_FIFO_SIZE];
+	data = PN532_CMD_GetFirmwareVersion;
+
+	while (1) {
+		if (((i = rfid_write(&data, sizeof(data))) == 0) &&
+		    ((i = rfid_read(output, PN532_FIFO_SIZE))) > 0)
+			break;
+
+		debug_printf("fw_res=%i\n", i);
+		pmu_wait_ms(490);
+		GPIOSetValue(LED_PORT, LED_BIT, LED_ON);
+		pmu_wait_ms(10);
+		GPIOSetValue(LED_PORT, LED_BIT, LED_OFF);
+	}
+
+	if (output[1] == 0x32)
+		debug_printf("PN532 firmware version: v%i.%i\n",
+			     output[2], output[3]);
+	else
+		debug("Unknown firmware version\n");
+}
+
+/* libnfc START */
+void loop_libnfc_rfid(void)
+{
+	int t, count, res;
+	uint8_t data, *p;
+
+	get_firmware_version();
+
+	debug_printf("in libnfc\n");
+
+    PN532_Packet buffer_put, buffer_get;
+
+	packet_init(&buffer_get, 0, 0xD5);
+	packet_init(&buffer_put, 1, 0xD4);
+
+	/* run RFID loop */
+	t = 0;
+	while (1) {
+        if ( LIBNFC != main_menu) { break; }
+
+		if (!GPIOGetValue(PN532_IRQ_PORT, PN532_IRQ_PIN)) {
+			GPIOSetValue(LED_PORT, LED_BIT, (t++) & 1);
+
+			data = 0x03;
+
+			spi_txrx(SPI_CS_PN532 | SPI_CS_MODE_SKIP_CS_DEASSERT,
+				 &data, sizeof(data), NULL, 0);
+
+			while (!GPIOGetValue(PN532_IRQ_PORT, PN532_IRQ_PIN)) {
+				spi_txrx((SPI_CS_PN532 ^ SPI_CS_MODE_SKIP_TX) |
+					 SPI_CS_MODE_SKIP_CS_ASSERT |
+					 SPI_CS_MODE_SKIP_CS_DEASSERT, NULL, 0,
+					 &data, sizeof(data));
+
+				if ((res = packet_put(&buffer_get, data)) > 0) {
+					/* add termination */
+					buffer_get.data[res++] = 0x00;
+					p = buffer_get.data;
+					count = res;
+					while (count--) {
+						usb_putchar(*p++);
+					}
+					usb_flush();
+#ifdef  DEBUG
+					debug("RX: ");
+					dump_packet(buffer_get.data, res);
+#endif
+				}
+			}
+
+			spi_txrx(SPI_CS_PN532 | SPI_CS_MODE_SKIP_CS_ASSERT,
+				 NULL, 0, NULL, 0);
+		}
+
+		while ((res = usb_getchar()) >= 0) {
+			if ((count =
+			     packet_put(&buffer_put, (uint8_t) res)) > 0) {
+				GPIOSetValue(LED_PORT, LED_BIT, (t++) & 1);
+				buffer_put.data[0] = 0x01;
+				buffer_put.data[count++] = 0x00;
+				spi_txrx(SPI_CS_PN532, buffer_put.data, count,
+					 NULL, 0);
+#ifdef  DEBUG
+				debug("TX: ");
+				dump_packet(&buffer_put.data[1], count - 1);
+#endif				 /*DEBUG*/
+				    break;
+			} else {
+				switch (count) {
+				case STATE_WAKEUP:
+					/* reset PN532 */
+					GPIOSetValue(PN532_RESET_PORT,
+						     PN532_RESET_PIN, 0);
+					pmu_wait_ms(100);
+					GPIOSetValue(PN532_RESET_PORT,
+						     PN532_RESET_PIN, 1);
+					pmu_wait_ms(400);
+					count = 0;
+					break;
+				case STATE_FIFOFLUSH:
+					/* flush PN532 buffers */
+					buffer_put.data[0] = 0x01;
+					memset(&buffer_put.data[1], 0,
+					       PN532_FIFO_SIZE);
+					spi_txrx(SPI_CS_PN532, buffer_put.data,
+						 PN532_FIFO_SIZE + 1, NULL, 0);
+					break;
+				}
+			}
+		}
+	}
+}
+/* libnfc END */

--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -1,0 +1,140 @@
+#include <openbeacon.h>
+#include "iap.h"
+#include "rfid.h"
+#include "usbserial.h"
+#include "libnfc.h"
+#include "arc.h"
+
+uint8_t main_menu = LIBNFC;
+uint8_t submenu = READ;
+uint8_t status = 0; /* 1: finished */
+
+/* Set and Handle Interrupts */
+void WAKEUP_IRQHandlerPIO2_0(void)
+{
+	debug_printf("Menu (Pressed 2_0)\n");
+	/* Clear pending IRQ */
+	LPC_SYSCON->STARTRSRP0CLR = STARTxPRP0_PIO2_0;
+	main_menu = CLONE;
+	if (0x01 == status) {
+	    submenu = WRITE;
+    }
+}
+
+void WAKEUP_IRQHandlerPIO0_1(void)
+{
+    debug_printf("Profile (Pressed 0_1)\n");
+    LPC_SYSCON->STARTRSRP0CLR = STARTxPRP0_PIO0_1;
+    dump_mifare_card();
+}
+
+void WAKEUP_IRQHandlerPIO1_0(void)
+{
+    debug_printf("OK (Pressed 1_0)\n");
+    LPC_SYSCON->STARTRSRP0CLR = STARTxPRP0_PIO1_0;
+	main_menu = LIBNFC;
+}
+
+void ButtonInit(void)
+{
+	NVIC_EnableIRQ(WAKEUP_PIO2_0_IRQn);
+
+	LPC_SYSCON->STARTAPRP0 = (LPC_SYSCON->STARTAPRP0 & ~STARTxPRP0_PIO2_0);
+	LPC_SYSCON->STARTRSRP0CLR = STARTxPRP0_PIO2_0;
+	LPC_SYSCON->STARTERP0 |= STARTxPRP0_PIO2_0;
+
+	NVIC_EnableIRQ(WAKEUP_PIO1_0_IRQn);
+
+	LPC_SYSCON->STARTAPRP0 = (LPC_SYSCON->STARTAPRP0 & ~STARTxPRP0_PIO1_0);
+	LPC_SYSCON->STARTRSRP0CLR = STARTxPRP0_PIO1_0;
+	LPC_SYSCON->STARTERP0 |= STARTxPRP0_PIO1_0;
+
+	NVIC_EnableIRQ(WAKEUP_PIO0_1_IRQn);
+
+	LPC_SYSCON->STARTAPRP0 = (LPC_SYSCON->STARTAPRP0 & ~STARTxPRP0_PIO0_1);
+	LPC_SYSCON->STARTRSRP0CLR = STARTxPRP0_PIO0_1;
+	LPC_SYSCON->STARTERP0 |= STARTxPRP0_PIO0_1;
+}
+
+void LEDInit(void)
+{
+	GPIOSetDir(LED_PORT, LED_BIT, 1);
+	GPIOSetValue(LED_PORT, LED_BIT, LED_OFF);
+
+	GPIOSetDir(0, 7, 1);
+	GPIOSetValue(0, 7, LED_OFF);
+
+	GPIOSetDir(1, 10, 1);
+	GPIOSetValue(1, 10, LED_OFF);
+
+	GPIOSetDir(1, 1, 1);
+	GPIOSetValue(1, 1, LED_OFF);
+}
+
+void LED_finished(void)
+{
+    for (uint8_t i = 0; i < 10; i++) {
+        pmu_wait_ms(50);
+        GPIOSetValue(0, 7, LED_OFF);
+        GPIOSetValue(1, 10, LED_OFF);
+        GPIOSetValue(1, 1, LED_OFF);
+        pmu_wait_ms(50);
+        GPIOSetValue(0, 7, LED_ON);
+        GPIOSetValue(1, 10, LED_ON);
+        GPIOSetValue(1, 1, LED_ON);
+    }
+    GPIOSetValue(0, 7, LED_OFF);
+    GPIOSetValue(1, 10, LED_OFF);
+    GPIOSetValue(1, 1, LED_OFF);
+}
+
+int main(void)
+{
+
+	/* Initialize GPIO (sets up clock) */
+	GPIOInit();
+
+	ButtonInit();
+
+    LEDInit();
+
+	/* UART setup */
+	UARTInit(115200, 0);
+
+	/* CDC USB Initialization */
+	usb_init();
+
+	/* Init Power Management Routines */
+	pmu_init();
+
+	/* Init RFID SPI interface */
+	rfid_init();
+
+	debug_printf("OpenPCD2 vTROOPERS15\n");
+
+	/* show LED to signal initialization */
+	GPIOSetValue(LED_PORT, LED_BIT, LED_ON);
+	pmu_wait_ms(500);
+
+    /* UID */
+    TDeviceUID uid;
+    debug_printf ("UID:");
+    iap_read_uid (&uid);
+    rfid_hexdump(&uid, DEVICE_UID_MEMBERS*4);
+
+	debug_printf ("You have passed the Test\n");
+	debug_printf ("What Test?\n");
+	debug_printf ("... the Debuginterfacetest\n");
+
+    while (1) {
+        switch (main_menu) {
+            case LIBNFC:
+                loop_libnfc_rfid();
+                break;
+            case CLONE:
+                loop_clone_rfid(LED_finished);
+                break;
+        }
+    }
+    return 0;
+}

--- a/arc/src/usbserial.c
+++ b/arc/src/usbserial.c
@@ -1,0 +1,186 @@
+/***************************************************************
+ *
+ * OpenBeacon.org - application specific USB functionality
+ *
+ * Copyright 2012 Milosch Meriac <meriac@openbeacon.de>
+ *
+ ***************************************************************
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; version 2.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ */
+#include <openbeacon.h>
+#include "usbserial.h"
+
+#define FIFO_SIZE (USB_CDC_BUFSIZE * 2)
+
+typedef struct
+{
+	uint8_t buffer[FIFO_SIZE];
+	uint16_t head, tail, count;
+} TFIFO;
+
+BOOL CDC_DepInEmpty;
+TFIFO fifo_BulkIn, fifo_BulkOut;
+
+int
+usb_putchar_irq (TFIFO * fifo, uint8_t data)
+{
+	if (fifo->count >= FIFO_SIZE)
+		return -1;
+
+	/* add data to FIFO */
+	fifo->count++;
+	fifo->buffer[fifo->head++] = data;
+
+	/* handle wrapping */
+	if (fifo->head == FIFO_SIZE)
+		fifo->head = 0;
+
+	return 0;
+}
+
+int
+usb_getchar_irq (TFIFO * fifo)
+{
+	int res;
+
+	if (!fifo->count)
+		return -1;
+
+	/* get data from FIFO */
+	fifo->count--;
+	res = fifo->buffer[fifo->tail++];
+
+	/* handle wrapping */
+	if (fifo->tail == FIFO_SIZE)
+		fifo->tail = 0;
+
+	return res;
+}
+
+int
+usb_getchar (void)
+{
+	int res;
+
+	__disable_irq ();
+	res = usb_getchar_irq (&fifo_BulkOut);
+	__enable_irq ();
+
+	return res;
+}
+
+int
+usb_putchar (uint8_t data)
+{
+	int res;
+
+	__disable_irq ();
+	/* if USB FIFO is full - flush */
+	if (fifo_BulkIn.count >= USB_CDC_BUFSIZE)
+		CDC_BulkIn ();
+	/* store new data in FIFO */
+	res = usb_putchar_irq (&fifo_BulkIn, data);
+	__enable_irq ();
+
+	return res;
+}
+
+void
+CDC_BulkIn (void)
+{
+	uint8_t *p;
+	uint32_t data;
+	uint16_t count;
+
+	if (!fifo_BulkIn.count)
+		return;
+
+	if (fifo_BulkIn.count > USB_CDC_BUFSIZE)
+		count = USB_CDC_BUFSIZE;
+	else
+		count = fifo_BulkIn.count;
+
+	USB_WriteEP_Count (CDC_DEP_IN, count);
+
+	while (count > 0)
+	{
+		if (count < (int) sizeof (data))
+		{
+			data = 0;
+			p = (uint8_t *) & data;
+			while (count)
+			{
+				count--;
+				*p++ = usb_getchar_irq (&fifo_BulkIn);
+			}
+		}
+		else
+		{
+			((uint8_t *) & data)[0] = usb_getchar_irq (&fifo_BulkIn);
+			((uint8_t *) & data)[1] = usb_getchar_irq (&fifo_BulkIn);
+			((uint8_t *) & data)[2] = usb_getchar_irq (&fifo_BulkIn);
+			((uint8_t *) & data)[3] = usb_getchar_irq (&fifo_BulkIn);
+			count -= 4;
+		}
+		USB_WriteEP_Block (data);
+	}
+
+	USB_WriteEP_Terminate (CDC_DEP_IN);
+}
+
+void
+usb_flush (void)
+{
+	__disable_irq ();
+	CDC_BulkIn ();
+	__enable_irq ();
+}
+
+void
+CDC_BulkOut (void)
+{
+	int count, bs;
+	uint32_t block;
+	uint8_t *p;
+
+	count = USB_ReadEP_Count (CDC_DEP_OUT);
+
+	while (count > 0)
+	{
+		block = USB_ReadEP_Block ();
+		bs = (count > (int) sizeof (block)) ? (int) sizeof (block) : count;
+		count -= bs;
+		p = (unsigned char *) &block;
+		while (bs--)
+			usb_putchar_irq (&fifo_BulkOut, *p++);
+	}
+
+	USB_ReadEP_Terminate (CDC_DEP_OUT);
+}
+
+void
+usb_init (void)
+{
+	/* initialize buffers */
+	bzero (&fifo_BulkIn, sizeof (fifo_BulkIn));
+	bzero (&fifo_BulkOut, sizeof (fifo_BulkOut));
+
+	CDC_Init ();
+	/* USB Initialization */
+	USB_Init ();
+	/* Connect to USB port */
+	USB_Connect (TRUE);
+}


### PR DESCRIPTION
Added a set of default Mifare Classic Keys which allows you to clone a specific set of Mifare Classic Cards (keys are obtained in libnfc-mode with mfoc).
Button left switches into read-Mode (and if reading is finished into write-Mode)
Button right switches to libnfc
Button (01 under the reset Button) dumps the content (1kb) which was read

Use Case:
Take the Badge put a MF-Classic Card (1k) on it push the Button on the left.
If it uses the hardcoded keys (A) wait (about a minute) till the LEDs are flashing.
Then put a Blank Card on it, press the Button on the left, and wait again.
You should now have a clone of your card with the original A-Keys and a Backup Key B (0xFF 0xFF 0xFF 0xFF 0xFF 0xFF), if you accidently something.

Libnfc still available (Button on the right).
